### PR TITLE
Add performance metrics data model

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,9 @@
-# st03-prediction-model
+# ST03 Prediction Model
+
+This repository contains a minimal example for predicting SAP workload response time using linear regression. The data model is defined in `data_model.py` and training logic in `train_model.py`.
+
+To train the model, place your historical data in `performance_data.csv` and run:
+
+```bash
+python train_model.py
+```

--- a/data_model.py
+++ b/data_model.py
@@ -1,0 +1,49 @@
+from dataclasses import dataclass
+from typing import Optional
+
+@dataclass
+class PerformanceRecord:
+    """Data model for performance metrics.
+
+    Predictor and target variables for linear regression.
+    """
+    # Predictor variables
+    entry_id: str
+    account: str
+    count: int
+    committi: float
+    dbprocti: Optional[float] = None
+    readdirti: Optional[float] = None
+    readseqti: Optional[float] = None
+    chngti: Optional[float] = None
+    procti: Optional[float] = None
+    cputi: Optional[float] = None
+    queueti: Optional[float] = None
+    rollwaitti: Optional[float] = None
+    generateti: Optional[float] = None
+    reploadti: Optional[float] = None
+    cualoadti: Optional[float] = None
+    dynploadti: Optional[float] = None
+    queti: Optional[float] = None
+    ddicti: Optional[float] = None
+    cpicti: Optional[float] = None
+    lockti: Optional[float] = None
+    insti: Optional[float] = None
+    updti: Optional[float] = None
+    delti: Optional[float] = None
+    rollinti: Optional[float] = None
+    rolloutti: Optional[float] = None
+    firstrecti: Optional[int] = None
+    lastrecti: Optional[int] = None
+    elapsedti: Optional[float] = None
+    rollti: Optional[float] = None
+    loadgenti: Optional[float] = None
+    dbti: Optional[float] = None
+    execution_ti: Optional[float] = None
+    data_send_ti: Optional[float] = None
+    data_receive_ti: Optional[float] = None
+    logon_ti: Optional[float] = None
+    authorization_ti: Optional[float] = None
+
+    # Target variable
+    respti: float

--- a/train_model.py
+++ b/train_model.py
@@ -1,0 +1,40 @@
+import pandas as pd
+from sklearn.linear_model import LinearRegression
+from sklearn.model_selection import train_test_split
+from sklearn.metrics import mean_squared_error
+from data_model import PerformanceRecord
+
+# Columns used as predictors
+PREDICTOR_COLUMNS = [
+    'ENTRY_ID', 'ACCOUNT', 'COUNT', 'COMMITTI', 'DBPROCTI', 'READDIRTI',
+    'READSEQTI', 'CHNGTI', 'PROCTI', 'CPUTI', 'QUEUETI', 'ROLLWAITTI',
+    'GENERATETI', 'REPLOADTI', 'CUALOADTI', 'DYNPLOADTI', 'QUETI', 'DDICTI',
+    'CPICTI', 'LOCKTI', 'INSTI', 'UPDTI', 'DELTI', 'ROLLINTI', 'ROLLOUTTI',
+    'FIRSTRECTI', 'LASTRECTI', 'ELAPSEDTI', 'ROLLTI', 'LOADGENTI', 'DBTI',
+    'EXECUTION_TI', 'DATA_SEND_TI', 'DATA_RECEIVE_TI', 'LOGON_TI',
+    'AUTHORIZATION_TI'
+]
+
+TARGET_COLUMN = 'RESPTI'
+
+def load_data(csv_path: str) -> pd.DataFrame:
+    """Load dataset from a CSV file."""
+    df = pd.read_csv(csv_path)
+    return df
+
+def train_linear_regression(df: pd.DataFrame) -> LinearRegression:
+    """Train a linear regression model for response time prediction."""
+    X = df[PREDICTOR_COLUMNS]
+    y = df[TARGET_COLUMN]
+    X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.2, random_state=42)
+
+    model = LinearRegression()
+    model.fit(X_train, y_train)
+    y_pred = model.predict(X_test)
+    mse = mean_squared_error(y_test, y_pred)
+    print(f"Test MSE: {mse:.2f}")
+    return model
+
+if __name__ == "__main__":
+    df = load_data('performance_data.csv')
+    model = train_linear_regression(df)


### PR DESCRIPTION
## Summary
- add `PerformanceRecord` dataclass modeling predictor and target features
- add training script using linear regression
- update README with instructions

## Testing
- `python -m py_compile data_model.py train_model.py`


------
https://chatgpt.com/codex/tasks/task_e_683ff3167c388325a27c215e8e12257f