### PR TITLE
Add SQLite training workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,12 @@
-# st03-prediction-model
+# ST03 Prediction Model
+
+This repository contains a minimal example for predicting SAP workload response
+time using linear regression. The data model is defined in `data_model.py` and
+training logic in `train_model.py`.
+
+The training script expects a SQLite database containing the performance
+tables. Assuming the database is called `performance_data.sqlite`, run:
+
+```bash
+python train_model.py performance_data.sqlite
+```

--- a/data_model.py
+++ b/data_model.py
@@ -1,0 +1,62 @@
+from dataclasses import dataclass
+from typing import Optional, List
+
+
+PREDICTOR_COLUMNS: List[str] = [
+    'ENTRY_ID', 'ACCOUNT', 'COUNT', 'COMMITTI', 'DBPROCTI', 'READDIRTI',
+    'READSEQTI', 'CHNGTI', 'PROCTI', 'CPUTI', 'QUEUETI', 'ROLLWAITTI',
+    'GENERATETI', 'REPLOADTI', 'CUALOADTI', 'DYNPLOADTI', 'QUETI', 'DDICTI',
+    'CPICTI', 'LOCKTI', 'INSTI', 'UPDTI', 'DELTI', 'ROLLINTI', 'ROLLOUTTI',
+    'FIRSTRECTI', 'LASTRECTI', 'ELAPSEDTI', 'ROLLTI', 'LOADGENTI', 'DBTI',
+    'EXECUTION_TI', 'DATA_SEND_TI', 'DATA_RECEIVE_TI', 'LOGON_TI',
+    'AUTHORIZATION_TI',
+]
+
+TARGET_COLUMN = 'RESPTI'
+
+@dataclass
+class PerformanceRecord:
+    """Data model for performance metrics.
+
+    Predictor and target variables for linear regression.
+    """
+    # Predictor variables
+    ENTRY_ID: str
+    ACCOUNT: str
+    COUNT: int
+    COMMITTI: float
+    DBPROCTI: Optional[float] = None
+    READDIRTI: Optional[float] = None
+    READSEQTI: Optional[float] = None
+    CHNGTI: Optional[float] = None
+    PROCTI: Optional[float] = None
+    CPUTI: Optional[float] = None
+    QUEUETI: Optional[float] = None
+    ROLLWAITTI: Optional[float] = None
+    GENERATETI: Optional[float] = None
+    REPLOADTI: Optional[float] = None
+    CUALOADTI: Optional[float] = None
+    DYNPLOADTI: Optional[float] = None
+    QUETI: Optional[float] = None
+    DDICTI: Optional[float] = None
+    CPICTI: Optional[float] = None
+    LOCKTI: Optional[float] = None
+    INSTI: Optional[float] = None
+    UPDTI: Optional[float] = None
+    DELTI: Optional[float] = None
+    ROLLINTI: Optional[float] = None
+    ROLLOUTTI: Optional[float] = None
+    FIRSTRECTI: Optional[int] = None
+    LASTRECTI: Optional[int] = None
+    ELAPSEDTI: Optional[float] = None
+    ROLLTI: Optional[float] = None
+    LOADGENTI: Optional[float] = None
+    DBTI: Optional[float] = None
+    EXECUTION_TI: Optional[float] = None
+    DATA_SEND_TI: Optional[float] = None
+    DATA_RECEIVE_TI: Optional[float] = None
+    LOGON_TI: Optional[float] = None
+    AUTHORIZATION_TI: Optional[float] = None
+
+    # Target variable
+    RESPTI: float

--- a/train_model.py
+++ b/train_model.py
@@ -1,0 +1,40 @@
+import sqlite3
+import sys
+
+import pandas as pd
+from sklearn.linear_model import LinearRegression
+from sklearn.model_selection import train_test_split
+from sklearn.metrics import mean_squared_error
+from data_model import PerformanceRecord, PREDICTOR_COLUMNS, TARGET_COLUMN
+
+def load_data(db_path: str, table: str = 'HITLIST_RESPTIME') -> pd.DataFrame:
+    """Load dataset from a SQLite database."""
+    conn = sqlite3.connect(db_path)
+    query = f"SELECT {', '.join(PREDICTOR_COLUMNS + [TARGET_COLUMN])} FROM {table}"
+    df = pd.read_sql_query(query, conn)
+    conn.close()
+    return df
+
+def train_linear_regression(df: pd.DataFrame) -> LinearRegression:
+    """Train a linear regression model for response time prediction."""
+    X = df[PREDICTOR_COLUMNS]
+    y = df[TARGET_COLUMN]
+    X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.2, random_state=42)
+
+    model = LinearRegression()
+    model.fit(X_train, y_train)
+    y_pred = model.predict(X_test)
+    mse = mean_squared_error(y_test, y_pred)
+    print(f"Test MSE: {mse:.2f}")
+    return model
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        print("Usage: python train_model.py <database_path> [table]")
+        sys.exit(1)
+
+    db_path = sys.argv[1]
+    table = sys.argv[2] if len(sys.argv) > 2 else 'HITLIST_RESPTIME'
+
+    df = load_data(db_path, table)
+    model = train_linear_regression(df)


### PR DESCRIPTION
## Summary
- read data from a SQLite database instead of CSV
- keep column names in uppercase to match the database
- expose predictor and target columns from the data model
- update training script usage instructions

## Testing
- `python -m py_compile data_model.py train_model.py`


------
https://chatgpt.com/codex/tasks/task_e_683ff3167c388325a27c215e8e12257f