### PR TITLE
Fix training on categorical columns

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ pip install -r requirements.txt
 
 The training script expects a SQLite database containing the performance
 tables. It automatically selects all predictor columns that exist in the
-database table. Assuming the database is called `performance_data.sqlite`, run:
+database table and will one-hot encode any categorical columns. Assuming the
+database is called `performance_data.sqlite`, run:
 
 ```bash
 python train_model.py performance_data.sqlite

--- a/train_model.py
+++ b/train_model.py
@@ -32,9 +32,20 @@ def load_data(db_path: str, table: str = 'HITLIST_RESPTIME') -> pd.DataFrame:
     return df
 
 def train_linear_regression(df: pd.DataFrame) -> LinearRegression:
-    """Train a linear regression model for response time prediction."""
+    """Train a linear regression model for response time prediction.
+
+    Any categorical columns (dtype=object) are automatically one-hot encoded
+    before training.
+    """
     feature_columns = [c for c in PREDICTOR_COLUMNS if c in df.columns]
     X = df[feature_columns]
+
+    # Convert categorical columns to numeric representation.  This prevents
+    # "could not convert string to float" errors when the dataset contains
+    # values such as account names.
+    if any(X.dtypes == "object"):
+        X = pd.get_dummies(X, drop_first=True)
+
     y = df[TARGET_COLUMN]
     X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.2, random_state=42)
 


### PR DESCRIPTION
## Summary
- handle string columns by one-hot encoding before training
- document automatic one-hot encoding in README

## Testing
- `pip install -r requirements.txt`
- `python train_model.py dummy.db`

------
https://chatgpt.com/codex/tasks/task_e_68402db7291c8325a0279ebe0c442b70